### PR TITLE
Allow expires_at to be specified as UNIX timestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,5 +41,5 @@ const expiredAccessToken = chance.accessToken({
 
 + `options`
   + `expireMode` -  Can be either **expires_at** or **expires_in**. When set to **expires_at** it generates a token which expires at a random date. When set to **expires_in** it generates a token which expires in a random number of seconds.
-  + `parseDate` - When is true and **expireMode** is **expires_at** it generates a date object, otherwise it generates a ISO string
+  + `dateFormat` - Used when **expireMode** is **expires_at** to determine the format of the **expires_at** field. Can be **date** to generate a date object, **unix** to generate a UNIX timestamp in seconds since epoch or **iso** to generate an ISO formatted string.
   + `expired` - When is true and **expireMode** is **expires_at** it generates a date in the past

--- a/index.js
+++ b/index.js
@@ -45,11 +45,19 @@ module.exports = function accessToken(options = {}) {
 
   if (opts.expireMode === expireModes.at) {
     const expirationDateValue = getExpirationDate(this, opts.expired);
-    const expirationDate = {
-      date: expirationDateValue,
-      iso: expirationDateValue.toISOString(),
-      unix: Math.round(expirationDateValue.getTime() / 1000),
-    }[opts.dateFormat];
+    let expirationDate;
+    switch (opts.dateFormat) {
+      case 'date':
+        expirationDate = expirationDateValue;
+        break;
+      case 'unix':
+        expirationDate = Math.round(expirationDateValue.getTime() / 1000);
+        break;
+      case 'iso':
+      default:
+        expirationDate = expirationDateValue.toISOString();
+        break;
+    }
 
     return Object.assign({}, baseAccessToken, {
       expires_at: expirationDate,

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const expireModes = {
 
 const tokenDefaultOptions = {
   expireMode: expireModes.in,
-  parseDate: false,
+  dateFormat: 'iso',
   expired: false,
 };
 
@@ -45,7 +45,11 @@ module.exports = function accessToken(options = {}) {
 
   if (opts.expireMode === expireModes.at) {
     const expirationDateValue = getExpirationDate(this, opts.expired);
-    const expirationDate = opts.parseDate ? expirationDateValue : expirationDateValue.toISOString();
+    const expirationDate = {
+      date: expirationDateValue,
+      iso: expirationDateValue.toISOString(),
+      unix: Math.round(expirationDateValue.getTime() / 1000),
+    }[opts.dateFormat];
 
     return Object.assign({}, baseAccessToken, {
       expires_at: expirationDate,

--- a/test/index.js
+++ b/test/index.js
@@ -36,18 +36,27 @@ describe('when creating an access token', () => {
         expect(token).to.have.property('expires_at');
       });
 
-      it('generates a expired_at property as date when parseDate is true', () => {
-        const token = chance.accessToken({ expireMode: 'expires_at', parseDate: true });
+      it('generates a expired_at property as date when dateFormat is "date"', () => {
+        const token = chance.accessToken({ expireMode: 'expires_at', dateFormat: 'date' });
 
         expect(token).to.have.property('expires_at');
         expect(isDate(token.expires_at)).to.be.equal(true);
       });
 
-      it('generates a expired_at property as ISO string when parseDate is false', () => {
-        const token = chance.accessToken({ expireMode: 'expires_at', parseDate: false });
+      it('generates a expired_at property as ISO string when dateFormat is "iso"', () => {
+        const token = chance.accessToken({ expireMode: 'expires_at', dateFormat: 'iso' });
 
         expect(token).to.have.property('expires_at');
         expect(isDate(token.expires_at)).to.be.equal(false);
+        expect(typeof token.expires_at).to.be.equal('string');
+      });
+
+      it('generates a expired_at property as UNIX time when dateFormat is "unix"', () => {
+        const token = chance.accessToken({ expireMode: 'expires_at', dateFormat: 'unix' });
+
+        expect(token).to.have.property('expires_at');
+        expect(isDate(token.expires_at)).to.be.equal(false);
+        expect(typeof token.expires_at).to.be.equal('number');
       });
 
       it('generates a expired token when expired option is true', () => {


### PR DESCRIPTION
Relates to https://github.com/lelylan/simple-oauth2/pull/277