### PR TITLE
Update package publishing settings

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 2.0.0
+- Change publishing settings to use package files and explicitly set the global registry
+
+## 1.0.0
+- Initial release

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.1",
   "description": "A simple chance mixin which generates a random access token",
   "main": "index.js",
+  "files": [
+    "index.js"
+  ],
   "devDependencies": {
     "chai": "^4.1.2",
     "chance": "^1.0.13",


### PR DESCRIPTION
+ Use the global npm registry as explicit project configuration
+ Use files instead of .npmignore pattern to publish only required module files to npm